### PR TITLE
[RK] Add LogLevels enum object, fix TS exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-rest-router",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "build": "tsc --build tsconfig.build.json && cp ./package.json ./build/package.json",
+    "build": "tsc --build tsconfig.build.json && cp ./package.json ./build/package.json && cp ./README.md ./build/README.md",
     "clean": "rm -rf build",
     "live-test": "bash ./example-consuming-client/build.sh",
     "clean-build": "npm run clean && npm run build",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "graphql-rest-router",
   "version": "1.0.0-alpha.13",
   "description": "",
-  "main": "./src/index.js",
-  "types": "./src/types.d.ts",
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "lint": "eslint . --ext .ts",
     "build": "tsc --build tsconfig.build.json && cp ./package.json ./build/package.json && cp ./README.md ./build/README.md",

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,13 +1,14 @@
 import { ILogger, ILogLevels, LogLevel } from './types';
 
 export const LogLevels: ILogLevels = {
+  SILENT: -1,
   ERROR: 0,
   WARN: 1,
   INFO: 2,
   DEBUG: 3,
 };
 
-export class Logger implements ILogger {
+export default class Logger implements ILogger {
   private loggerObject: ILogger;
   private logLevel: LogLevel;
 

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,6 +1,13 @@
-import { ILogger, LogLevel } from './types';
+import { ILogger, ILogLevels, LogLevel } from './types';
 
-export default class Logger implements ILogger {
+export const LogLevels: ILogLevels = {
+  ERROR: 0,
+  WARN: 1,
+  INFO: 2,
+  DEBUG: 3,
+};
+
+export class Logger implements ILogger {
   private loggerObject: ILogger;
   private logLevel: LogLevel;
 
@@ -18,25 +25,25 @@ export default class Logger implements ILogger {
   }
 
   public debug(message: string): void {
-    if (this.shouldLog(LogLevel.DEBUG)) {
+    if (this.shouldLog(LogLevels.DEBUG)) {
       this.loggerObject.debug(message);
     }
   }
 
   public info(message: string): void {
-    if (this.shouldLog(LogLevel.INFO)) {
+    if (this.shouldLog(LogLevels.INFO)) {
       this.loggerObject.info(message);
     }
   }
 
   public warn(message: string): void {
-    if (this.shouldLog(LogLevel.WARN)) {
+    if (this.shouldLog(LogLevels.WARN)) {
       this.loggerObject.warn(message);
     }
   }
 
   public error(message: string): void {
-    if (this.shouldLog(LogLevel.ERROR)) {
+    if (this.shouldLog(LogLevels.ERROR)) {
       this.loggerObject.error(message);
     }
   }

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -11,7 +11,7 @@ import {
   IOperationVariableMap, IOperationVariable, IResponse,
 }  from './types';
 
-import Logger from './Logger';
+import { Logger } from './Logger';
 
 const PATH_VARIABLES_REGEX = /:([A-Za-z]+)/g;
 

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -11,7 +11,7 @@ import {
   IOperationVariableMap, IOperationVariable, IResponse,
 }  from './types';
 
-import { Logger } from './Logger';
+import Logger from './Logger';
 
 const PATH_VARIABLES_REGEX = /:([A-Za-z]+)/g;
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -7,7 +7,8 @@ import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { parse, DocumentNode, getOperationAST } from 'graphql';
 
 import Route from './Route';
-import { IGlobalConfiguration, IMountableItem, IConstructorRouteOptions, LogLevel } from './types';
+import { IGlobalConfiguration, IMountableItem, IConstructorRouteOptions } from './types';
+import { LogLevels } from './Logger';
 
 // TODO: Fix this in ts config and change to import
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -18,7 +19,7 @@ const DEFAULT_CONFIGURATION: IGlobalConfiguration = {
   logger: undefined,
   auth: undefined,
   proxy: undefined,
-  defaultLogLevel: LogLevel.ERROR,
+  defaultLogLevel: LogLevels.ERROR,
   defaultTimeoutInMs: 10000,
   defaultCacheTimeInMs: 0,
   autoDiscoverEndpoints: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import Router from './Router';
 import Route from './Route';
+import { LogLevels } from './Logger';
 
 import * as OpenApi from './OpenApi';
 import ApiBlueprint from './ApiBlueprint';
 
 export default Router;
-export { Route, OpenApi, ApiBlueprint };
+export { Route, OpenApi, ApiBlueprint, LogLevels };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,4 @@ import ApiBlueprint from './ApiBlueprint';
 
 export * from './types';
 export default Router;
-export { Route, OpenApi, LogLevels, ApiBlueprint }; // TODO: these exports are unusable in TS. How to fix?
-
+export { Route, OpenApi, LogLevels, ApiBlueprint };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,7 @@ import { LogLevels } from './Logger';
 import * as OpenApi from './OpenApi';
 import ApiBlueprint from './ApiBlueprint';
 
+export * from './types';
 export default Router;
-export { Route, OpenApi, ApiBlueprint, LogLevels };
+export { Route, OpenApi, LogLevels, ApiBlueprint }; // TODO: these exports are unusable in TS. How to fix?
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,6 @@ import { AxiosBasicCredentials, AxiosProxyConfig, AxiosInstance } from 'axios';
 import { DocumentNode } from 'graphql';
 import express from 'express';
 
-export default Router;
-
 export interface IGlobalConfiguration {
   cacheEngine?: ICacheEngine;
   defaultTimeoutInMs?: number;
@@ -98,9 +96,10 @@ export interface ILogger {
   debug: (message: string) => void;
 }
 
-export type LogLevel = 0 | 1 | 2 | 3;
+export type LogLevel = -1 | 0 | 1 | 2 | 3;
 
 export interface ILogLevels {
+  SILENT: LogLevel,
   ERROR: LogLevel,
   WARN: LogLevel,
   INFO: LogLevel,

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,9 +98,12 @@ export interface ILogger {
   debug: (message: string) => void;
 }
 
-export const enum LogLevel {
-  ERROR = 0,
-  WARN = 1,
-  INFO = 2,
-  DEBUG = 3,
+export type LogLevel = 0 | 1 | 2 | 3;
+
+export interface ILogLevels {
+  ERROR: LogLevel,
+  WARN: LogLevel,
+  INFO: LogLevel,
+  DEBUG: LogLevel,
 }
+

--- a/test/Logger.test.js
+++ b/test/Logger.test.js
@@ -1,6 +1,7 @@
 const { assert } = require('chai');
-const { mock, spy } = require('sinon');
+const { mock } = require('sinon');
 const Logger = require('../src/Logger').default;
+const LogLevels = require('../src/Logger').LogLevels;
 
 const loggerObject = {
   warn: () => undefined,
@@ -9,7 +10,7 @@ const loggerObject = {
   error: () => undefined
 }
 const logMessage = 'Test Message';
-const defaultLogLevel = 3;
+const defaultLogLevel = LogLevels.DEBUG;
 
 describe('Logger', () => {
   describe('#constructor', () => {
@@ -50,7 +51,7 @@ describe('Logger', () => {
       it('no ops with lower log level', () => {
         mockLogger.expects('info').never();
 
-        logger.setLogLevel(0);
+        logger.setLogLevel(LogLevels.ERROR);
         logger.info(logMessage);
 
         mockLogger.verify();
@@ -75,7 +76,7 @@ describe('Logger', () => {
       it('no ops with lower log level', () => {
         mockLogger.expects('warn').never();
 
-        logger.setLogLevel(0);
+        logger.setLogLevel(LogLevels.ERROR);
         logger.warn(logMessage);
 
         mockLogger.verify();
@@ -100,7 +101,7 @@ describe('Logger', () => {
       it('no ops with lower log level', () => {
         mockLogger.expects('debug').never();
 
-        logger.setLogLevel(0);
+        logger.setLogLevel(LogLevels.ERROR);
         logger.debug(logMessage);
 
         mockLogger.verify();
@@ -124,7 +125,7 @@ describe('Logger', () => {
       it('no ops with lower log level', () => {
         mockLogger.expects('error').never();
 
-        logger.setLogLevel(-1);
+        logger.setLogLevel(LogLevels.SILENT);
         logger.error(logMessage);
 
         mockLogger.verify();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
   "exclude": [
     "node_modules/**",
     "example-consuming-client",
-    "test"
+    "test",
+    "build"
   ]
 }


### PR DESCRIPTION
# Summary

Add LogLevels enum object, can be imported from the package as such

```typescript
import GraphQLRestRouter, { LogLevels } from 'graphql-rest-router';
```

The LogLevels object can be used like this:

```typescript
const api = new GraphQLRestRouter(ENDPOINT, SCHEMA, {
  logger,
  defaultLogLevel: LogLevels.DEBUG,
});
```

# Other Changes

1. Add README to build.
2. During the implementation of this object, I have found an issue with the TypeScript setup for this project. Because our `types` field in the package.json file was pointed at `types.d.ts`, TypeScript was treating this file as the main entry point of the application. Only `Router` was exported in types. To fix this, we change the types declaration file to `index.d.ts` where we export all the types for the project, as well as any exports we want to expose. Prior to this change, if you tried to import any of our project's named exports in a typescript application, you would get an error similar to this.

<img width="973" alt="Screen Shot 2021-10-01 at 11 32 55 AM" src="https://user-images.githubusercontent.com/1987265/135674391-9e455070-375d-4b10-8d47-ae51265dcbc2.png">
