### PR TITLE
[RK] Transform request & response fix, add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,43 @@ api.mount('GetUser').withOptions({
 });
 ```
 
+### Request & Response Transformations
+
+GraphQL Rest Router allows the developer to add transformations on incoming requests or outgoing responses. Say the shape of data coming from GraphQL is not what your consuming application needs. Instead of putting transformational logic into your consuming components, you can encapsulate it into the REST layer.
+
+```js
+import GraphQLRestRouter from 'graphql-rest-router';
+
+const api = new GraphQLRestRouter('http://localhost:1227', schema);
+
+api.mount('GetImages').withOption('transformResponse', (response => {
+  const { data, errors } = response;
+
+  return {
+    data: {
+      // Turn images array into image URL map
+      images: data.images?.reduce((acc, img) => {
+        acc[img.url] = img;
+      }, {}),
+      errors,
+    }
+  };
+}));
+```
+
+You can also modify the outgoing request:
+
+```js
+import GraphQLRestRouter from 'graphql-rest-router';
+
+const api = new GraphQLRestRouter('http://localhost:1227', schema);
+
+api.mount('GetImages').at('/images').withOption('transformRequest', (request, headers) => {
+  headers['X-My-Header'] = 'MyValue';
+  return request;
+});
+```
+
 ### Logging
 
 GraphQL Rest Router is capable of logging incoming requests and errors. When creating your router, you may use a logger of your own choice. GraphQL Rest Router allows you to configure log levels. The logger parameter must implement [ILogger](https://github.com/Econify/graphql-rest-router/blob/29cc328f23b8dd579a6f4af242266460e95e7d69/src/types.ts#L101-L107), and is compatible with most standard logging libraries.

--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ api.mount('GetUser').withOptions({
 
 ### Request & Response Transformations
 
-GraphQL Rest Router allows the developer to add transformations on incoming requests or outgoing responses. Say the shape of data coming from GraphQL is not what your consuming application needs. Instead of putting transformational logic into your consuming components, you can encapsulate it into the REST layer.
+GraphQL Rest Router allows the developer to add transformations on incoming requests or outgoing responses. By default, the regular axios transformers are used.
+
+Say the shape of data coming from GraphQL is not what your consuming application needs. Instead of putting transformational logic into your consuming components, you can encapsulate it into the REST layer.
 
 ```js
 import GraphQLRestRouter from 'graphql-rest-router';
@@ -355,7 +357,7 @@ api.mount('GetImages').withOption('transformResponse', (response => {
 }));
 ```
 
-You can also modify the outgoing request:
+You can also modify the outgoing request. These transforms should return a string request, but also allow you to modify the request headers.
 
 ```js
 import GraphQLRestRouter from 'graphql-rest-router';

--- a/example-consuming-client/package-lock.json
+++ b/example-consuming-client/package-lock.json
@@ -28,7 +28,7 @@
       "version": "1.0.0-alpha.14",
       "license": "ISC",
       "dependencies": {
-        "axios": "^0.21.1",
+        "axios": "^0.21.4",
         "express": "^4.17.1",
         "graphql": "^14.0.2",
         "redis": "^3.1.2",
@@ -1074,7 +1074,7 @@
         "@types/sinon": "^7.0.2",
         "@typescript-eslint/eslint-plugin": "^4.6.1",
         "@typescript-eslint/parser": "^4.6.1",
-        "axios": "^0.21.1",
+        "axios": "^0.21.4",
         "chai": "^4.2.0",
         "eslint": "^7.12.1",
         "eslint-plugin-import": "^2.22.1",

--- a/example-consuming-client/src/api.ts
+++ b/example-consuming-client/src/api.ts
@@ -18,9 +18,8 @@ api.mount('GetCharacters').at('/characters/').withOptions({
 });
 api.mount('GetCharacterById').at('/characters/:id');
 
-api.mount('GetLocations').at('/locations').transformResponse(response => {
-  const json = JSON.parse(response);
-  const { data, errors } = json;
+api.mount('GetLocations').at('/locations').withOption('transformResponse', (response) => {
+  const { data, errors } = response;
 
   return {
     data: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-alpha.14",
       "license": "ISC",
       "dependencies": {
-        "axios": "^0.24.0",
+        "axios": "^0.21.4",
         "express": "^4.17.1",
         "graphql": "^14.0.2",
         "redis": "^3.1.2",
@@ -1286,11 +1286,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/balanced-match": {
@@ -7079,11 +7079,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "4.0.3"
   },
   "dependencies": {
-    "axios": "^0.24.0",
+    "axios": "^0.21.4",
     "express": "^4.17.1",
     "graphql": "^14.0.2",
     "redis": "^3.1.2",

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -3,7 +3,7 @@
 
 import { IncomingHttpHeaders } from 'http';
 import { DocumentNode, parse, print, getOperationAST } from 'graphql';
-import { AxiosTransformer, AxiosInstance, AxiosRequestConfig } from 'axios';
+import axios, { AxiosTransformer, AxiosInstance, AxiosRequestConfig } from 'axios';
 import * as express from 'express';
 
 import { createHash } from 'crypto';
@@ -103,8 +103,8 @@ export default class Route implements IMountableItem {
   private schema!: DocumentNode;
   private logger!: Logger;
 
-  private transformRequestFn: AxiosTransformer[] = [];
-  private transformResponseFn: AxiosTransformer[] = [];
+  private transformRequestFn = axios.defaults.transformRequest as AxiosTransformer[];
+  private transformResponseFn = axios.defaults.transformResponse as AxiosTransformer[];
 
   private staticVariables: Record<string, unknown> = {};
   private defaultVariables: Record<string, unknown> = {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import Router from './Router';
-import { AxiosBasicCredentials, AxiosProxyConfig, AxiosInstance } from 'axios';
+import { AxiosBasicCredentials, AxiosProxyConfig, AxiosInstance, AxiosTransformer } from 'axios';
 import { DocumentNode } from 'graphql';
 import express from 'express';
 
@@ -45,6 +45,8 @@ export interface IRouteOptions {
   cacheKeyIncludedHeaders?: string[];
   staticVariables?: Record<string, unknown>;
   defaultVariables?: Record<string, unknown>;
+  transformRequest?: AxiosTransformer;
+  transformResponse?: AxiosTransformer;
 }
 
 export interface IOperationVariableMap {

--- a/test/Route.test.js
+++ b/test/Route.test.js
@@ -118,8 +118,14 @@ describe('Route', () => {
     it('should return data as JSON if response is stringified JSON', async () => {
       const stringifiedJSON = "{\"data\":{\"users\":[{\"id\":1,\"name\":\"Charles Barkley\"}]}}";
       const transformResponse = route.transformResponseFn[0];
-      const transitional = {}
-      const data = await transformResponse.bind(transitional)(stringifiedJSON);
+      const transitional = {
+        silentJSONParsing: true,
+        forcedJSONParsing: true,
+        clarifyTimeoutError: false
+      };
+      // HACK: transitional default not bound to axios function by default. This is fixed in
+      // later versions of axios (> 0.24.0), please remove after upgrade.
+      const data = await transformResponse.bind({ transitional })(stringifiedJSON);
 
       assert.strictEqual(typeof data, 'object');
     });


### PR DESCRIPTION
## Issue Link

[Issue 6](https://github.com/Econify/graphql-rest-router/issues/6)

## Description

- Add default axios transform to response, eliminates need to JSON parse in response transform
- Add default axios transform to request. Current transform request is broken because it is not using the default axios transform.
- Add documentation for this in README

## PR Requirements

Before requesting review this criteria must be met:

- [x] Overall test coverage >= current master?
- [x] Documentation included -- README.md updated, docs, etc. (if any behavioral changes)?
- [ ] Backwards compatibility (if breaking change)?
