### PR TITLE
[MM, RK] 1.0.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-rest-router",
-  "version": "1.0.0-alpha.14",
+  "version": "1.0.0-beta.0",
   "description": "",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
## Upgrading From Alpha

There is one breaking change with the release of `1.0.0-beta.0`: Transform response callbacks now receive parsed data as opposed to the stringified version. Therefore, any callback passed in this way must no longer parse prior to processing.

Chained route methods such as `disableCache()` or `transformResponse()` have been deprecated. Please use `withOption()` or `withOptions()` instead. Support for chained route methods will be removed in a future version.

For example:
```js

// not this
api.mount('GetUserById').at('/users/:id').disableCache().transformResponse(cb);

// this
api.mount('GetUserById').at('/users/:id').withOptions({
  cacheTimeInMs: 0,
  transformResponse: cb,
});
```

Change log:
- Dependency updates
- Development tooling (example consuming client, tests, coverage, commit hooks, CONTRIBUTING.md, issues / pr templates, linting)
- Typescript support
- Caching (Redis, custom, in-memory)
- Schemaless operations
- Schema Query optimization
- Log Levels enumeration
- Transform request & response full implementation (breaking change)
- withOptions and withOption configuration convention
