### PR TITLE
[RK] Resolve default transforms bug, don't override defaults in axios

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ api.listen(3000, () => {
   - [Express.js Usage](#usage-with-express)
   - [KOA Usage](#usage-with-koa)
   - [Examples](#code-examples)
+- [Upgrading From Alpha](#upgrading-from-alpha)
 
 ## Overview
 
@@ -370,7 +371,6 @@ api.mount('GetImages').at('/images').withOption('transformRequest', (request, he
 
 GraphQL Rest Router supports robust logging of incoming requests and errors. On instantiation, a logger of your choice can be injected with configurable log levels. The logger object must implement [ILogger](https://github.com/Econify/graphql-rest-router/blob/29cc328f23b8dd579a6f4af242266460e95e7d69/src/types.ts#L101-L107), and log levels must be one of the following [ILogLevels](https://github.com/Econify/graphql-rest-router/blob/f83881d30bdb329a306ebb94fdf577fb065f2e6e/src/types.ts#L107-L113).
 
-
 ```js
 import GraphQLRestRouter, { LogLevels } from 'graphql-rest-router';
 
@@ -525,7 +525,8 @@ As of the time of this writing, a KOA extension for GraphQL Rest Router is not a
 
 See the [example client](/example-consuming-client) in this repo for code examples.
 
-## Upgrading from alpha
+## Upgrading from Alpha
+
 There is one breaking change with the release of `1.0.0-beta.0`: Transform response callbacks now receive parsed data as opposed to the stringified version. Therefore, any callback passed in this way must no longer parse prior to processing.
 
 Chained route methods such as `disableCache()` or `transformResponse()` have been deprecated. Please use `withOption()` or `withOptions()` instead. Support for chained route methods will be removed in a future version.
@@ -542,4 +543,3 @@ api.mount('GetUserById').at('/users/:id').withOptions({
   transformResponse: cb,
 });
 ```
-

--- a/example-consuming-client/package-lock.json
+++ b/example-consuming-client/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../build": {
       "name": "graphql-rest-router",
-      "version": "1.0.0-alpha.14",
+      "version": "1.0.0-beta.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.4",

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -124,8 +124,8 @@ export default class Route implements IMountableItem {
   private schema!: DocumentNode;
   private logger!: Logger;
 
-  private transformRequestFn = axios.defaults.transformRequest as AxiosTransformer[];
-  private transformResponseFn = axios.defaults.transformResponse as AxiosTransformer[];
+  private transformRequestFn: AxiosTransformer[] = [];
+  private transformResponseFn: AxiosTransformer[] = [];
 
   private staticVariables: Record<string, unknown> = {};
   private defaultVariables: Record<string, unknown> = {};
@@ -136,6 +136,21 @@ export default class Route implements IMountableItem {
 
   constructor(configuration: IConstructorRouteOptions) {
     this.configureRoute(configuration);
+  }
+
+  private setDefaultTransforms() {
+    const defaultTransformResponse = Array.isArray(axios.defaults.transformResponse)
+      && axios.defaults.transformResponse[0];
+    const defaultTransformRequest = Array.isArray(axios.defaults.transformRequest)
+      && axios.defaults.transformRequest[0];
+
+    if (defaultTransformResponse) {
+      this.transformResponseFn.push(defaultTransformResponse);
+    }
+
+    if (defaultTransformRequest) {
+      this.transformRequestFn.push(defaultTransformRequest);
+    }
   }
 
   private configureRoute(configuration: IConstructorRouteOptions) {
@@ -151,6 +166,7 @@ export default class Route implements IMountableItem {
       throw new Error('A valid schema is required to initialize a Route');
     }
 
+    this.setDefaultTransforms();
     this.schema = typeof schema === 'string' ? parse(schema) : schema;
     this.axios = axios;
     this.logger = new Logger();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["es2020"],
+    "lib": ["es2019"],
     "module": "commonjs",
-    "target": "es2020",
+    "target": "es2019",
 
     "outDir": "build/src/",
     "rootDir": "src/",


### PR DESCRIPTION
## Description

Resolve default transforms bug:

Default transforms array in Axios was assigned by reference on each Route object. This caused the assignment of transforms to write to the default array for all routes. 

Solution: Don't assign by reference, create a new array and push the default transform to it.

## PR Requirements

Before requesting review this criteria must be met:

- [x] Overall test coverage >= current master?
- [x] Documentation included -- README.md updated, docs, etc. (if any behavioral changes)?
- [x] Backwards compatibility (if breaking change)?
